### PR TITLE
docker-compose.yml: Jekyllコンテナのタイムゾーンを Asia/Tokyo に固定

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
   jekyll:
     platform: linux/x86_64
     image: jekyll/jekyll:4.2.0
+    environment:
+      - TZ=Asia/Tokyo
     volumes:
       - ./:/srv/jekyll
     command: jekyll serve --watch --trace


### PR DESCRIPTION
## Summary
- `docker-compose.yml` のjekyllサービスに `TZ=Asia/Tokyo` を追加
- コンテナのデフォルトタイムゾーンがUTC-5相当だったため、front matterの日付（タイムゾーン未指定）がコンテナのローカル時刻基準で「未来」と判定され、当日公開予定の記事ページが404になっていた

Closes #63

## Test plan
- [x] `docker compose up` 後、コンテナ内 `date` がJST（ホストと同じ日付・時刻）になることを確認
- [x] `curl http://localhost:4000/` が200を返すことを確認